### PR TITLE
Åpne for Kotlin 2.3

### DIFF
--- a/buildSrc/src/main/kotlin/aap.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/aap.conventions.gradle.kts
@@ -54,8 +54,8 @@ kotlin {
     jvmToolchain(21)
     compilerOptions {
         jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
-        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3)
+        languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3)
 
         // Bruk et unikt navn for <submodule>.kotlin_module for hver Gradle-submodul, for å unngå navnekollisjoner i
         // multi-modul prosjekt, hvor vi inkluderer flere av våre kotlin-moduler i samme jar-fil eller


### PR DESCRIPTION
Lar oss bruke API-er og språkegenskaper som ble lansert med Kotlin 2.3 (var: 2.2)